### PR TITLE
Update to debian stretch and use default-jdk 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,8 @@ RUN set -x && \
     curl \
     locales \
     build-essential \
-    git 
+    git && \
+    /root/post-install
 
 # The mkdir statement is necessary, more info here:
 # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=863199
@@ -40,9 +41,7 @@ RUN set -x && \
   mkdir -p /usr/share/man/man1 && \ 
   apt-get update -qq && \
   apt-get install -y \
-  default-jdk
-
-RUN set -x && \
+  default-jdk && \ 
   apt-get install -y --no-install-recommends ca-certificates wget vim && \
   sed -i 's/^# en_US.UTF-8 UTF-8$/en_US.UTF-8 UTF-8/g' /etc/locale.gen && locale-gen && \
   update-locale LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 && \
@@ -66,13 +65,8 @@ RUN set -x && \
   apt-get purge -y --auto-remove wget  && \
   mv /root/aliases /root/.aliases && \
   echo "source ~/.aliases" >> /root/.bashrc && \
-  /root/create-user redis 4201 redis 4201  && \
-  /root/create-user elasticsearch 4202 elasticsearch 4202 && \
-  /root/create-user mongodb 4203 mongodb 4203 && \
-  /root/create-user rabbitmq 4204 rabbitmq 4204 && \
   /root/create-user java 4205 java 4205 && \
   /root/create-user py 4206 py 4206 && \
-  /root/create-user node 4207 node 4207 && \
   /root/create-user docker 4242 docker 4242 && \
   /root/post-install
 
@@ -99,7 +93,7 @@ EXPOSE 8000
 RUN pip install tox==${TOX_VERSION}
 
 # Define default command.
-CMD ["bash"]
+CMD ["bash"]docker build -t aerialtech/debian-python3-tox-dynamodb .
 
 # BUILD IT
 #  docker build -t aerialtech/debian-python3-tox-dynamodb .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,109 @@
+FROM python:3.6-slim-jessie
+
+USER root
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    TERM=linux \
+    INITRD=No \
+    LANGUAGE=en_US.UTF-8 \
+    LANG=en_US.UTF-8  \
+    LC_ALL=en_US.UTF-8 \
+    LC_CTYPE=en_US.UTF-8 \
+    LC_MESSAGES=en_US.UTF-8 \
+    LC_ALL=en_US.UTF-8 \
+    GOSU_VERSION=1.9 \
+    TINI_VERSION=v0.13.2 \
+    TOX_VERSION=3.2.1
+
+#add root asset (aliases and fix user id)
+ADD files/* /root/
+
+
+# Install curl, locales, apt-utils, gosu and tini
+# create en_US.UTF-8
+# update distribution package
+# add few common alias to root user
+# add utilities (create user, post install script)
+# create airdock user list
+RUN set -x && \
+  apt-get update -qq && \
+  apt-get install -y \
+    apt-utils \
+    curl \
+    locales \
+    build-essential \
+    git \
+    oracle-java8-installer \
+  && \
+  apt-get install -y --no-install-recommends ca-certificates wget vim && \
+  sed -i 's/^# en_US.UTF-8 UTF-8$/en_US.UTF-8 UTF-8/g' /etc/locale.gen && locale-gen && \
+  update-locale LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 && \
+  apt-get update -y && \
+  dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"  && \
+  wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"  && \
+  wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"  && \
+  export GNUPGHOME="$(mktemp -d)"  && \
+  gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4  && \
+  gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu  && \
+  rm -r /usr/local/bin/gosu.asc  && \
+  chmod +x /usr/local/bin/gosu  && \
+  gosu nobody true  && \
+  wget -O /usr/local/bin/tini "https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini" && \
+  wget -O /usr/local/bin/tini.asc "https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini.asc" && \
+  gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 && \
+  gpg --batch --verify /usr/local/bin/tini.asc /usr/local/bin/tini  && \
+  rm -r "$GNUPGHOME" /usr/local/bin/tini.asc  && \
+  chmod +x /usr/local/bin/tini  && \
+  apt-get purge -y --auto-remove ca-certificates wget  && \
+  mv /root/aliases /root/.aliases && \
+  echo "source ~/.aliases" >> /root/.bashrc && \
+  /root/create-user redis 4201 redis 4201  && \
+  /root/create-user elasticsearch 4202 elasticsearch 4202 && \
+  /root/create-user mongodb 4203 mongodb 4203 && \
+  /root/create-user rabbitmq 4204 rabbitmq 4204 && \
+  /root/create-user java 4205 java 4205 && \
+  /root/create-user py 4206 py 4206 && \
+  /root/create-user node 4207 node 4207 && \
+  /root/create-user docker 4242 docker 4242 && \
+  /root/post-install
+
+# Define default workdir
+WORKDIR /root
+
+
+# Add java dynamic memory script
+COPY java-dynamic-memory-opts /srv/java/
+COPY jdk-8u152-linux-x64.tar.gz /tmp/
+COPY dynamodb_local_latest.tar.gz /tmp/
+
+# Install Oracle JDK 8u11
+RUN cd /tmp && \
+    tar xf jdk-8u152-linux-x64.tar.gz -C /srv/java && \
+    rm -f jdk-8u152-linux-x64.tar.gz && \
+    ln -s /srv/java/jdk* /srv/java/jdk && \
+    ln -s /srv/java/jdk /srv/java/jvm && \
+    chown -R java:java /srv/java && \
+    mkdir -p /opt/dynamodb-local && mkdir -p /srv/dynamodb-local && \
+    tar xf /tmp/dynamodb_local_latest.tar.gz -C /opt/dynamodb-local && \
+    rm -f /tmp/dynamodb_local_latest.tar.gz && \
+    chown -R java:java /opt/dynamodb-local && chown -R java:java /srv/dynamodb-local && \
+    /root/post-install
+
+# Define commonly used JAVA_HOME variable
+# Add /srv/java and jdk on PATH variable
+ENV JAVA_HOME=/srv/java/jre \
+    PATH=${PATH}:/srv/java/jdk/jre/bin:/srv/java
+
+# Expose DynamoDB local port
+EXPOSE 8000
+
+# Prepare for build and tests
+RUN pip install tox==${TOX_VERSION}
+
+# Define default command.
+CMD ["bash"]
+
+# BUILD IT
+#  docker build -t sportebois/debian-python3-tox-dynamodb .
+# RUN IT
+#  docker run -it --rm -p 8000:8000 sportebois/debian-python3-tox-dynamodb

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6-slim-jessie
+FROM python:3.6.7-slim-jessie
 
 USER root
 
@@ -33,7 +33,6 @@ RUN set -x && \
     locales \
     build-essential \
     git \
-    oracle-java8-installer \
   && \
   apt-get install -y --no-install-recommends ca-certificates wget vim && \
   sed -i 's/^# en_US.UTF-8 UTF-8$/en_US.UTF-8 UTF-8/g' /etc/locale.gen && locale-gen && \
@@ -50,7 +49,7 @@ RUN set -x && \
   gosu nobody true  && \
   wget -O /usr/local/bin/tini "https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini" && \
   wget -O /usr/local/bin/tini.asc "https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini.asc" && \
-  gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 && \
+  gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 && \
   gpg --batch --verify /usr/local/bin/tini.asc /usr/local/bin/tini  && \
   rm -r "$GNUPGHOME" /usr/local/bin/tini.asc  && \
   chmod +x /usr/local/bin/tini  && \
@@ -70,16 +69,19 @@ RUN set -x && \
 # Define default workdir
 WORKDIR /root
 
+# This part requires that the current folder contains the specific jdk tar file.
+# Visit https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html to download
+# the appropriate version.
 
 # Add java dynamic memory script
 COPY java-dynamic-memory-opts /srv/java/
-COPY jdk-8u152-linux-x64.tar.gz /tmp/
+COPY jdk-8u191-linux-x64.tar.gz /tmp/
 COPY dynamodb_local_latest.tar.gz /tmp/
 
-# Install Oracle JDK 8u11
+# Install Oracle JDK 8u191
 RUN cd /tmp && \
-    tar xf jdk-8u152-linux-x64.tar.gz -C /srv/java && \
-    rm -f jdk-8u152-linux-x64.tar.gz && \
+    tar xf jdk-8u191-linux-x64.tar.gz -C /srv/java && \
+    rm -f jdk-8u191-linux-x64.tar.gz && \
     ln -s /srv/java/jdk* /srv/java/jdk && \
     ln -s /srv/java/jdk /srv/java/jvm && \
     chown -R java:java /srv/java && \

--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# Docker image with Python3 + tox + DynamoDBlocal on Debian
+
+Build/tool image with Python3.6, tox and dynamodb installed and ready to run. (plus other tools like curl and vi)
+
+Useful to run tests in CI.
+
+To start dynamoDBlocal, run the `/root/start-ddb.sh` startup script. Dynamo will start listening on port 8000

--- a/files/aliases
+++ b/files/aliases
@@ -1,0 +1,11 @@
+# Control ls
+alias ls='ls --color=auto'
+alias ll='ls --color=auto -l'
+alias l='ls --color=auto -lA'
+
+# Create parent directories on demand
+alias mkdir='mkdir -pv'
+
+## set some other defaults
+alias df='df -H'
+alias du='du -ch'

--- a/files/create-user
+++ b/files/create-user
@@ -1,0 +1,17 @@
+#!/bin/bash
+# create user and group with specific uid/gid
+# usage:
+#   create-user username uid groupname gid
+#
+USER_NAME=$1
+USER_UID=$2
+GROUP_NAME=$3
+GROUP_GID=$4
+
+groupadd $GROUP_NAME -g $GROUP_GID
+useradd -u $USER_UID --home-dir /srv/$USER_NAME --create-home --system --no-user-group $USER_NAME
+usermod -g $GROUP_NAME $USER_NAME
+ln -s /srv/$USER_NAME /var/lib/$USER_NAME
+chown -R $USER_NAME:$GROUP_NAME /var/lib/$USER_NAME
+
+echo "create user $USER_NAME ($USER_UID) and group $GROUP_NAME ($GROUP_GID), Home /srv/$USER_NAME (/var/lib/$USER_NAME for backward compatibility)."

--- a/files/post-install
+++ b/files/post-install
@@ -1,0 +1,6 @@
+#!/bin/bash
+# perform a clean up at end of install (build with dockerfile)
+#
+
+apt-get clean
+rm -rf /var/lib/apt/lists/* /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/files/start-ddb.sh
+++ b/files/start-ddb.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+nohup java -Djava.library.path=/opt/dynamodb-local/DynamoDBLocal_lib -jar /opt/dynamodb-local/DynamoDBLocal.jar -sharedDb --dbPath /srv/dynamodb-local &

--- a/java-dynamic-memory-opts
+++ b/java-dynamic-memory-opts
@@ -1,0 +1,18 @@
+#!/bin/sh
+# example usage: 
+# exec java $(java-dynamic-memory-opts 80) -jar myfatjar.jar
+
+# JVM uses only 1/4 of system memory by default
+DEFAULT_MEM_JAVA_PERCENT=80
+
+if [ -n "$1" ]
+  then
+    MEM_JAVA_PERCENT=$1
+  else
+    MEM_JAVA_PERCENT=$DEFAULT_MEM_JAVA_PERCENT
+fi
+
+MEM_TOTAL_KB=$(cat /proc/meminfo | grep MemTotal | awk '{print $2}')
+MEM_JAVA_KB=$(($MEM_TOTAL_KB * $MEM_JAVA_PERCENT / 100))
+
+echo "-Xmx${MEM_JAVA_KB}k"


### PR DESCRIPTION
This PR updates the container image components. The goal is to remove the need for having the Java JAR into the directory where the docker will be built to ensure that the build can be performed automatically. 

Here are the notable changes:
- Debian: from `jessie` to `stretch`
- Python: from `3.6.0` to `3.6.7`
- Java: from `8u152` to `default-jdk` 

This build was tested locally. 