### PR TITLE
Tag image with Python 3.8.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -93,7 +93,7 @@ EXPOSE 8000
 RUN pip install tox==${TOX_VERSION}
 
 # Define default command.
-CMD ["bash"]docker build -t aerialtech/debian-python3-tox-dynamodb .
+CMD ["bash"]
 
 # BUILD IT
 #  docker build -t aerialtech/debian-python3-tox-dynamodb .


### PR DESCRIPTION
I realized in the previous PR that we only have a single tag for this image in our Docker Hub. This is inconvenient if people are relying on previous versions. 

This PR targets a new branch `3.8.1` which relates to the Python version and will be used as the tag. 

Additional changes:

- There was a messed up line in the Dockerfile, this PR cleans that up as well. 